### PR TITLE
[Infra][Prod] Upgrade MySQL announcement

### DIFF
--- a/prod/17app/announcement.yaml
+++ b/prod/17app/announcement.yaml
@@ -1,25 +1,25 @@
 needMaintenance: true
 sendPubnub: true
-startAt: 2023-02-10 04:30:00 (GMT+0800)
-endAt: 2023-02-10 05:00:00 (GMT+0800)
+startAt: 2023-03-27 04:00:00 (GMT+0800)
+endAt: 2023-03-27 05:00:00 (GMT+0800)
 image: "1032766c-4027-4d6e-8f48-6a46d02a50a0.png"
 announcements:
     EN:
         title: "System Maintenance"
         description: "Dear users,\n
-          Our servers will be down for routine maintenance from 2023/02/09 20:30 UTC to 2023/02/09 21:00. We apologize for the inconvenience!"
+          Our servers will be down for routine maintenance from 2023/03/26 20:00 UTC to 2023/03/26 21:00. We apologize for the inconvenience!"
         pic: "17baobao.jpg"
     TW:
         title: "系統維修公告"
         description: "親愛的17用戶\n
-          17LIVE APP 預計於 2023/02/10 04:30 (GMT+8) 進行系統維修，並於 2023/02/10 05:00 (GMT+8) 重新開放，期間無法登入與使用，造成您的不便還請見諒，感謝您的支持與諒解，謝謝！ 17LIVE營運團隊敬上。"
+          17LIVE APP 預計於 2023/03/27 04:00 (GMT+8) 進行系統維修，並於 2023/03/27 05:00 (GMT+8) 重新開放，期間無法登入與使用，造成您的不便還請見諒，感謝您的支持與諒解，謝謝！ 17LIVE營運團隊敬上。"
         pic: "17baobao.jpg"
     JP:
         title: "サーバーメンテナンスについて"
         description: "いつも17LIVEをご利用いただき、誠にありがとうございます。\n
           この度、下記の時間帯にてサーバーメンテナンスを実施させていただきます\n\n
           ■ メンテナンス日時\n
-          2023年2月10日(金) AM5:30 ～ AM6:00\n
+          2023年3月27日(月) AM5:00 ～ AM6:00\n
           ※メンテナンス時間は前後する場合がございます。\n\n
           ■ メンテナンスに伴う影響\n
           メンテナンス開始時に全ての配信は終了され、上記時間帯は全てのサービスをご利用いただくことができなくなります。\n\n
@@ -29,5 +29,5 @@ announcements:
     CN:
         title: "系统维修公告"
         description: "亲爱的17用户\n
-          17LIVE APP 预计于 2023/02/10 04:30 (GMT+8) 进行系统维修，并于 2023/02/10 05:00 (GMT+8) 重新开放，期间无法登入与使用，造成您的不便还请见谅，感谢您的支持与谅解，谢谢！ 17LIVE营运团队敬上。"
+          17LIVE APP 预计于 2023/03/27 04:00 (GMT+8) 进行系统维修，并于 2023/03/27 05:00 (GMT+8) 重新开放，期间无法登入与使用，造成您的不便还请见谅，感谢您的支持与谅解，谢谢！ 17LIVE营运团队敬上。"
         pic: "17baobao.jpg"


### PR DESCRIPTION
MySQL Disaster Recovery Drills ([ref](https://17media.slack.com/archives/C0PAD7W5R/p1679539303204099))
- Execution time：2023/03/27 04:00 ~ 05:00 UTC+8
- Duration: 1 hours
- Purpose: In order to maintain high system availability, we need to simulate MySQL outage disaster recovery drills.